### PR TITLE
feat: initial commit with basic simulator structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ Datadog simulation tool / mock
 - `random_slow_receive` - chance for a request to hang for a while before responding. float 0.0 to 1.0
 - `random_bad_response` - chance to receive a status 500 response. float 0.0 to 1.0
 - `random_network_lag` - maximum random network lag on receiving request and responding, msec
+- `disable_json_parsing` - print out raw json payload without unmarshalling, bool

--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ Datadog simulation tool / mock
 ### Flags:
 - `port` - overrides the application default port (8083)
 - `random_no_auth` - chance to mock a failed auth error and get a 403 response. float 0.0 to 1.0
-- `random_no_receive` - chance for a request to hang for a while before responding. float 0.0 to 1.0
+- `random_slow_receive` - chance for a request to hang for a while before responding. float 0.0 to 1.0
 - `random_bad_response` - chance to receive a status 500 response. float 0.0 to 1.0
+- `random_network_lag` - maximum random network lag on receiving request and responding, msec

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # datadoglib
 Datadog simulation tool / mock
+
+## Usage
+```go run main.go```
+
+### Flags:
+- `port` - overrides the application default port (8083)
+- `random_no_auth` - chance to mock a failed auth error and get a 403 response. float 0.0 to 1.0
+- `random_no_receive` - chance for a request to hang for a while before responding. float 0.0 to 1.0
+- `random_bad_response` - chance to receive a status 500 response. float 0.0 to 1.0

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/klauspost/compress v1.15.12
 )
+
+require github.com/goccy/go-json v0.9.11

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/relex/datadoglib
+
+go 1.19
+
+require (
+	github.com/go-chi/chi/v5 v5.0.7
+	github.com/klauspost/compress v1.15.12
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/go-chi/chi/v5 v5.0.7 h1:rDTPXLDHGATaeHvVlLcR4Qe0zftYethFucbjVQ1PxU8=
 github.com/go-chi/chi/v5 v5.0.7/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/goccy/go-json v0.9.11 h1:/pAaQDLHEoCq/5FFmSKBswWmK6H0e8g4159Kc/X/nqk=
+github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/klauspost/compress v1.15.12 h1:YClS/PImqYbn+UILDnqxQCZ3RehC9N318SU3kElDUEM=
 github.com/klauspost/compress v1.15.12/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/go-chi/chi/v5 v5.0.7 h1:rDTPXLDHGATaeHvVlLcR4Qe0zftYethFucbjVQ1PxU8=
+github.com/go-chi/chi/v5 v5.0.7/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/klauspost/compress v1.15.12 h1:YClS/PImqYbn+UILDnqxQCZ3RehC9N318SU3kElDUEM=
+github.com/klauspost/compress v1.15.12/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"io"
 	"log"
@@ -39,7 +40,12 @@ func main() {
 		WriteTimeout: serverTimeout,
 	}
 
-	panic(srv.ListenAndServe())
+	err := srv.ListenAndServe()
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Fatal("error while serving http", err)
+	}
+
+	log.Println("exiting the application normally")
 }
 
 func parseConfig() {

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"io"
 	"log"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/gzip"
 )
 

--- a/main.go
+++ b/main.go
@@ -83,16 +83,13 @@ func randomFailMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		var networkLag time.Duration
 		if config.randomNetworkLag > 0 {
-			networkLag = time.Duration(rand.Intn(config.randomNetworkLag)) * time.Millisecond
+			networkLag := time.Duration(rand.Intn(config.randomNetworkLag)) * time.Millisecond
+			defer time.Sleep(networkLag)
+			time.Sleep(networkLag)
 		}
 
-		time.Sleep(networkLag)
-
 		next.ServeHTTP(w, r)
-
-		time.Sleep(networkLag)
 	})
 }
 

--- a/main.go
+++ b/main.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"io"
+	"log"
+	"math/rand"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/klauspost/compress/gzip"
+)
+
+const (
+	serverTimeout = time.Minute
+)
+
+var config struct {
+	serverPort        string
+	failAuthChance    float64
+	noReceiveChance   float64
+	badResponseChance float64
+}
+
+func main() {
+	parseConfig()
+
+	log.Println("starting the server at port " + config.serverPort)
+	srv := http.Server{
+		Addr:         ":" + config.serverPort,
+		Handler:      getRouter(),
+		ReadTimeout:  serverTimeout,
+		WriteTimeout: serverTimeout,
+	}
+
+	panic(srv.ListenAndServe())
+}
+
+func parseConfig() {
+	flag.StringVar(&config.serverPort, "port", "8083", "local port to launch the server at")
+	flag.Float64Var(&config.failAuthChance, "random_no_auth", 0, "chance to fail authentication, from 0.0 to 1.0")
+	flag.Float64Var(&config.noReceiveChance, "random_no_receive", 0, "chance to stop receiving data, from 0.0 to 1.0")
+	flag.Float64Var(&config.badResponseChance, "random_bad_response", 0, "chance to return a non-200 response status code, from 0.0 to 1.0")
+	flag.Parse()
+}
+
+func getRouter() *chi.Mux {
+	mux := chi.NewMux()
+
+	mux.Use(middleware.StripSlashes)
+	mux.Use(randomFailMiddleware)
+
+	mux.Post("/", handleLogs)
+
+	return mux
+}
+
+func randomFailMiddleware(next http.Handler) http.Handler {
+	rand.Seed(time.Now().UnixNano())
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if config.failAuthChance > rand.Float64() {
+			log.Println("triggered a fail auth chance, returning status 403")
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		if config.noReceiveChance > rand.Float64() {
+			log.Println("triggered a stop receiving chance, sleeping for 30 seconds")
+			time.Sleep(time.Second * 30)
+			return
+		}
+		if config.badResponseChance > rand.Float64() {
+			log.Println("triggered a bad response chance, returning status 500")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func handleLogs(w http.ResponseWriter, r *http.Request) {
+	reader, err := gzip.NewReader(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Println(err)
+		return
+	}
+
+	dataBytes, err := io.ReadAll(reader)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Println(err)
+		return
+	}
+
+	var requestData []map[string]string
+	err = json.Unmarshal(dataBytes, &requestData)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Println(err, string(dataBytes))
+		return
+	}
+
+	log.Println(requestData)
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ const (
 var config struct {
 	serverPort        string
 	failAuthChance    float64
-	noReceiveChance   float64
+	slowReceiveChance float64
 	badResponseChance float64
 }
 
@@ -42,7 +42,7 @@ func main() {
 func parseConfig() {
 	flag.StringVar(&config.serverPort, "port", "8083", "local port to launch the server at")
 	flag.Float64Var(&config.failAuthChance, "random_no_auth", 0, "chance to fail authentication, from 0.0 to 1.0")
-	flag.Float64Var(&config.noReceiveChance, "random_no_receive", 0, "chance to stop receiving data, from 0.0 to 1.0")
+	flag.Float64Var(&config.slowReceiveChance, "random_slow_receive", 0, "chance to receive data slowly, from 0.0 to 1.0")
 	flag.Float64Var(&config.badResponseChance, "random_bad_response", 0, "chance to return a non-200 response status code, from 0.0 to 1.0")
 	flag.Parse()
 }
@@ -67,8 +67,8 @@ func randomFailMiddleware(next http.Handler) http.Handler {
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}
-		if config.noReceiveChance > rand.Float64() {
-			log.Println("triggered a stop receiving chance, sleeping for 30 seconds")
+		if config.slowReceiveChance > rand.Float64() {
+			log.Println("triggered a slow receive chance, sleeping for 30 seconds")
 			time.Sleep(time.Second * 30)
 			return
 		}

--- a/main.go
+++ b/main.go
@@ -52,13 +52,15 @@ func parseConfig() {
 	flag.Parse()
 }
 
-func getRouter() *chi.Mux {
+func getRouter() chi.Router {
 	mux := chi.NewMux()
 
 	mux.Use(middleware.StripSlashes)
 	mux.Use(randomFailMiddleware)
 
-	mux.Post("/", handleLogs)
+	mux.Route("/api/v2", func(r chi.Router) {
+		r.Post("/logs", handleLogs)
+	})
 
 	return mux
 }

--- a/main.go
+++ b/main.go
@@ -80,16 +80,16 @@ func randomFailMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		var networkLagMsec time.Duration
+		var networkLag time.Duration
 		if config.randomNetworkLag > 0 {
-			networkLagMsec = time.Duration(rand.Intn(config.randomNetworkLag))
+			networkLag = time.Duration(rand.Intn(config.randomNetworkLag)) * time.Millisecond
 		}
 
-		time.Sleep(networkLagMsec * time.Millisecond)
+		time.Sleep(networkLag)
 
 		next.ServeHTTP(w, r)
 
-		time.Sleep(networkLagMsec * time.Millisecond)
+		time.Sleep(networkLag)
 	})
 }
 

--- a/main.go
+++ b/main.go
@@ -106,7 +106,9 @@ func handleLogs(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			log.Println(err)
+			return
 		}
+		w.WriteHeader(http.StatusOK)
 		return
 	}
 


### PR DESCRIPTION
Basic datadog simulator, useful for loadtesting slog-agent.  
Accepts the requests, ungzips/unmarshals them to validate the data and returns a response code.  
See README.md for optional flags.